### PR TITLE
Fix creation of HTML elements with createElementNS.

### DIFF
--- a/src/Document.js
+++ b/src/Document.js
@@ -76,6 +76,9 @@ module.exports = class Document extends Node {
   }
 
   createElementNS(ns, name) {
+    if (ns === 'http://www.w3.org/1999/xhtml') {
+      return this.createElement(name);
+    }
     return new HTMLElement(this, name + ':' + ns);
   }
 

--- a/test/all.js
+++ b/test/all.js
@@ -1,5 +1,5 @@
 const {title, assert, async, log} = require('tressa');
-const {CustomElementRegistry, CustomEvent, Document, Event, HTMLElement, HTMLUnknownElement} = require('../basichtml.js');
+const {CustomElementRegistry, CustomEvent, Document, Event, HTMLElement, HTMLTemplateElement, HTMLUnknownElement} = require('../basichtml.js');
 
 title('basicHTML');
 assert(
@@ -457,6 +457,8 @@ assert(
   document.createElementNS('svg', 'test').nodeName === 'test:svg',
   'createElementNS simply puts tags and namespace together'
 );
+
+assert(document.createElementNS('http://www.w3.org/1999/xhtml', 'template') instanceof HTMLTemplateElement, 'createElementNS uses createElement for HTML namespace');
 
 assert(
   document.createElement('something').tagName == 'something',


### PR DESCRIPTION
This allows full coverage for a related change to
`@ungap/create-content`.

Issue WebReflection/hyperHTML#311