### PR TITLE
Allow CustomEvent to be created

### DIFF
--- a/src/CustomEvent.js
+++ b/src/CustomEvent.js
@@ -11,4 +11,9 @@ module.exports = class CustomEvent extends Event {
     super(type, eventInitDict);
     this.detail = eventInitDict.detail;
   }
+
+  initCustomEvent(type, bubbles, cancelable, detail) {
+    this.initEvent(type, bubbles, cancelable);
+    this.detail = detail;
+  }
 };

--- a/src/Document.js
+++ b/src/Document.js
@@ -83,8 +83,14 @@ module.exports = class Document extends Node {
   }
 
   createEvent(name) {
-    if (name !== 'Event') throw new Error(name + ' not implemented');
-    return new Event();
+    switch (name) {
+      case 'Event':
+        return new Event();
+      case 'CustomEvent':
+        return new CustomEvent();
+      default:
+        throw new Error(name + ' not implemented');
+    }
   }
 
   createRange() {

--- a/src/Document.js
+++ b/src/Document.js
@@ -1,5 +1,6 @@
 const CustomElementRegistry = require('./CustomElementRegistry');
 const Event = require('./Event');
+const CustomEvent = require('./CustomEvent');
 const Node = require('./Node');
 const DocumentType = require('./DocumentType');
 const Attr = require('./Attr');

--- a/test/all.js
+++ b/test/all.js
@@ -354,6 +354,13 @@ assert(
   'CustomEvent also works as expected'
 );
 
+var createdCustomEvent = document.createEvent('CustomEvent');
+createdCustomEvent.initCustomEvent('custom', true, true, 'detail');
+assert(
+  createdCustomEvent.detail === 'detail',
+  'CustomEvent can be created procedurally'
+);
+
 log('## Comments');
 let comment = document.createComment('Here a comment');
 assert(comment.textContent === 'Here a comment');


### PR DESCRIPTION
Currently basicHTML is throwing an error when using HyperHTML element as it uses hyperHTML which uses @ungap/custom-event to create custom events.

This invokes `document.createEvent('CustomEvent')` which is not handled by basicHTML.

I added the changes needed to make this possible.