### PR TITLE
Allow removeEventListener in listener callback

### DIFF
--- a/src/EventTarget.js
+++ b/src/EventTarget.js
@@ -73,7 +73,7 @@ module.exports = class EventTarget {
     if (!event.eventPhase) defineProperty(event, 'eventPhase', {configurable: true, value: Event.AT_TARGET});
     do {
       if (type in node._eventTarget) {
-        node._eventTarget[type].callbacks.some(
+        [...node._eventTarget[type].callbacks].some(
           cb => (cb(event), event.cancelImmediateBubble)
         );
       }


### PR DESCRIPTION
Having a callback with a call to `removeEventListener` on the same EventTarget causes the listeners list to change hence to skip some listener.

[Here an example](https://codesandbox.io/s/vigorous-sunset-ujqg4?file=/src/index.js)
```js
const { EventTarget, Event } = require("basichtml");

const e = new EventTarget();
e.addEventListener("test", function test() {
  e.removeEventListener("test", test);
  console.log("test 1");
});
e.addEventListener("test", function test() {
  // this never runs because of the `removeEventListener` in previous call
  console.log("test 2");
});
e.addEventListener("test", function test() {
  // this runs because the iterator kept going
  console.log("test 3");
});
e.dispatchEvent(new Event("test"));
```